### PR TITLE
Demo-Page with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js: stable
+install:
+  - yarn --cwd './example/' install
+script:
+  - yarn --cwd './example/' build
+deploy:
+  provider: pages
+  local-dir: ./example/build
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ React implementation of the [Spritz speed-reading technique](http://spritzinc.co
 
 Inspired by Luis Ivan's [Spritzer](https://github.com/luisivan/spritzer).
 
-## **[Demo](https://vicrazumov.com)**
+## **[Demo](https://vicrazumov.github.io/React.Spritz/)**
 
 ## Installation
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -2,6 +2,7 @@
   "name": "example",
   "version": "0.1.0",
   "private": true,
+  "homepage": "./",
   "dependencies": {
     "react": "^16.6.0",
     "react-dom": "^16.6.0",

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>React.Spritz</title>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
Hey @vicrazumov 
Thanks a lot for the new version. Since I was not very helpful codewise I thought I could at least bring the demo-page you did in a CI so it's always up to date and not dependant on your website. 

Steps for you tu setup:
* accept this PR
* goto https://github.com/settings/tokens create a token. 
* got https://travis-ci.org/ login with your github account
* Enable your Repo:
![screenshot 2018-10-29 at 14 44 04](https://user-images.githubusercontent.com/992878/47654097-65853a80-db8a-11e8-91f5-2600b16f31b3.png)
* ADD GITHUB_TOKEN to travis with the generated token
![screenshot 2018-10-29 at 14 44 48](https://user-images.githubusercontent.com/992878/47654191-96fe0600-db8a-11e8-92de-de99ac318fae.png)


From now on on each commit the demo-page is automatically generated and you can see it here;
https://vicrazumov.github.io/React.Spritz/